### PR TITLE
.NET 9のサポートを追加する

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,13 +13,15 @@ jobs:
       fail-fast: false
       matrix:
         vm_image: [ubuntu-latest, windows-latest]
-        framework_version: [net48, net8.0]
+        framework_version: [net48, net8.0, net9.0]
         exclude:
           - vm_image: ubuntu-latest
             framework_version: net48
         include:
           - framework_version: net8.0
-            dotnet-sdk-version: 8.0.x  
+            dotnet-sdk-version: 8.0.x
+          - framework_version: net9.0
+            dotnet-sdk-version: 9.0.x
 
     runs-on: ${{ matrix.vm_image }}
    

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -19,9 +19,7 @@ jobs:
             framework_version: net48
         include:
           - framework_version: net8.0
-            dotnet-sdk-version: 8.0.x
           - framework_version: net9.0
-            dotnet-sdk-version: 9.0.x
 
     runs-on: ${{ matrix.vm_image }}
    
@@ -37,10 +35,11 @@ jobs:
           fetch-depth: 1
   
       - name: dotnet SDK のセットアップ
-        if: ${{ matrix.dotnet-sdk-version }}
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet-sdk-version }}
+          dotnet-version: |
+            8.0.x
+            9.0.x
           dotnet-quality: 'ga'
 
       - name: アプリケーションのビルド

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: dotnet SDK のセットアップ
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          8.0.x
+          9.0.x
+        dotnet-quality: 'ga'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/tests/Test.TsunaCan.HelloWorld/Test.TsunaCan.HelloWorld.csproj
+++ b/tests/Test.TsunaCan.HelloWorld/Test.TsunaCan.HelloWorld.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
#### PR Classification
新機能: .NET 9.0フレームワークのサポート追加

#### PR Summary
.NET 9.0フレームワークをビルドおよびテストの対象に追加しました。
- `build-pr.yml`ファイルの`matrix`に`net9.0`を追加
- `Test.TsunaCan.HelloWorld.csproj`ファイルの`<TargetFrameworks>`タグに`net9.0`を追加
